### PR TITLE
Fix xpath error in project chatbot module

### DIFF
--- a/static/src/css/project_chatbot.css
+++ b/static/src/css/project_chatbot.css
@@ -1,0 +1,26 @@
+/* Project Dify Chatbot CSS */
+
+.project-chatbot-container {
+    margin-bottom: 10px;
+}
+
+.project-chatbot-banner {
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.project-form-chatbot-banner {
+    border-radius: 6px;
+}
+
+.project-list-helper {
+    font-size: 14px;
+}
+
+.project-chatbot-banner .btn {
+    white-space: nowrap;
+}
+
+.project-chatbot-banner i {
+    color: #17a2b8;
+}

--- a/static/src/js/project_chatbot.js
+++ b/static/src/js/project_chatbot.js
@@ -1,0 +1,26 @@
+// Project Dify Chatbot JavaScript
+console.log('Project Dify Chatbot loaded');
+
+function toggleProjectChatbot() {
+    console.log('Toggle project chatbot');
+    // TODO: Implement chatbot toggle functionality
+    alert('Chatbot functionality coming soon!');
+}
+
+function showProjectChatbot() {
+    console.log('Show project chatbot');
+    // TODO: Implement chatbot display functionality
+    alert('Project guidance chatbot coming soon!');
+}
+
+function openProjectAssistant() {
+    console.log('Open project assistant');
+    // TODO: Implement project assistant functionality
+    alert('Project assistant coming soon!');
+}
+
+function launchProjectHelper() {
+    console.log('Launch project helper');
+    // TODO: Implement project helper functionality
+    alert('Project helper coming soon!');
+}

--- a/views/project_chatbot_templates.xml
+++ b/views/project_chatbot_templates.xml
@@ -8,7 +8,7 @@
             <field name="model">project.project</field>
             <field name="inherit_id" ref="project.view_project_kanban"/>
             <field name="arch" type="xml">
-                <xpath expr="//div[hasclass('o_kanban_view')]" position="before">
+                <kanban position="before">
                     <div class="project-chatbot-container">
                         <div class="alert alert-info project-chatbot-banner" style="margin: 10px;">
                             <div class="d-flex align-items-center">
@@ -23,7 +23,7 @@
                             </div>
                         </div>
                     </div>
-                </xpath>
+                </kanban>
             </field>
         </record>
 
@@ -33,7 +33,7 @@
             <field name="model">project.project</field>
             <field name="inherit_id" ref="project.edit_project"/>
             <field name="arch" type="xml">
-                <xpath expr="//form" position="before">
+                <form position="before">
                     <div class="project-form-chatbot-banner bg-light p-3 mb-3" style="border-left: 4px solid #007bff;">
                         <div class="d-flex align-items-center">
                             <i class="fa fa-lightbulb-o me-3" style="font-size: 20px; color: #007bff;"/>
@@ -46,7 +46,7 @@
                             </button>
                         </div>
                     </div>
-                </xpath>
+                </form>
             </field>
         </record>
 
@@ -56,7 +56,7 @@
             <field name="model">project.project</field>
             <field name="inherit_id" ref="project.view_project"/>
             <field name="arch" type="xml">
-                <xpath expr="//tree" position="before">
+                <tree position="before">
                     <div class="project-list-helper bg-info text-white p-2 mb-2" style="border-radius: 4px;">
                         <div class="d-flex align-items-center justify-content-between">
                             <span>
@@ -68,7 +68,7 @@
                             </button>
                         </div>
                     </div>
-                </xpath>
+                </tree>
             </field>
         </record>
 
@@ -78,7 +78,7 @@
             <field name="model">res.config.settings</field>
             <field name="inherit_id" ref="project.res_config_settings_view_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//div[hasclass('app_settings_block')]" position="before">
+                <xpath expr="//div[@class='app_settings_block']" position="before">
                     <div class="row mt16 o_settings_container">
                         <div class="col-12 col-lg-6 o_setting_box">
                             <div class="o_setting_left_pane"/>


### PR DESCRIPTION
Update Odoo XML view XPath expressions and create missing static files to resolve module installation errors.

The module failed to install with a `ParseError` because several XPath expressions (e.g., `//div[hasclass('o_kanban_view')]`, `//form`, `//tree`) in `project_chatbot_templates.xml` could not locate their target elements in the parent views, likely due to changes in Odoo 18's view structure. Additionally, the manifest referenced non-existent static JS and CSS files. This PR replaces the problematic XPath expressions with more direct and compatible selectors and creates the necessary static files.

---
<a href="https://cursor.com/background-agent?bcId=bc-eadb843b-d7ab-4e6a-87f6-bee371b095d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eadb843b-d7ab-4e6a-87f6-bee371b095d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

